### PR TITLE
Add RG policy template definitions

### DIFF
--- a/Policy/required-tag-option-list.json
+++ b/Policy/required-tag-option-list.json
@@ -1,0 +1,40 @@
+Policy definition name: Require tag on resource groups and 
+Policy definition description: This policy template requires a certain tag to be provided for a resource group.  It must be provided when the resource group is created.
+Policy definition category: Resource Group
+
+{
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+                },
+                {
+                    "not": {
+                        "field": "[concat('tags[', parameters('tagName'), ']')]",
+                        "in": "[parameters('listOfAllowedTagValues')]"
+                    }
+                }
+            ]
+        },
+        "then": {
+            "effect": "deny"
+        }
+    },
+    "parameters": {
+        "tagName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of the required tag"
+            }
+        },
+        "listOfAllowedTagValues": {
+            "type": "Array",
+            "metadata": {
+                "displayName": "Allowed tag values",
+                "description": "The list of allowed tag values"
+            }
+        }
+    }
+}

--- a/Policy/required-tag-option-list.json
+++ b/Policy/required-tag-option-list.json
@@ -1,5 +1,5 @@
-Policy definition name: Require tag on resource groups and 
-Policy definition description: This policy template requires a certain tag to be provided for a resource group.  It must be provided when the resource group is created.
+Policy definition name: Require tag on resource groups and restrict possible values
+Policy definition description: This policy template requires a certain tag to be provided for a resource group.  It must be provided when the resource group is created.  You must also provide a list of possible values for the tag to be enforced.
 Policy definition category: Resource Group
 
 {

--- a/Policy/required-tag.json
+++ b/Policy/required-tag.json
@@ -1,0 +1,31 @@
+Policy definition name: Require tag on resource groups
+Policy definition description: This policy template requires a certain tag to be provided for a resource group.  It must be provided when the resource group is created.
+Policy definition category: Resource Group
+
+{
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+                },
+                {
+                    "field": "[concat('tags[', parameters('tagName'), ']')]",
+                    "exists": "false"
+                }
+            ]
+        },
+        "then": {
+            "effect": "deny"
+        }
+    },
+    "parameters": {
+        "tagName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of the required tag"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add policy template definitions: one for a requiring a tag for a free form value, and one for a tag with a set list of possible values.

Use the free form value definition for something like costCenter, and the set list of values for something like environment: dev, test, prod, etc.
